### PR TITLE
Remove `eject` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,6 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react-intl": "^2.3.0",
     "react-intl-loader": "^1.0.2",
     "react-redux": "^7.1.0",
-    "react-scripts": "^5.0.1",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.9",
     "redux-observable": "^1.0.0",
@@ -77,8 +76,7 @@
     "build": "react-app-rewired build",
     "build-android": "mobile=true react-app-rewired build && npx cap sync android",
     "build-ios": "mobile=true react-app-rewired build && npx cap sync ios",
-    "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
+    "test": "react-app-rewired test"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
The eject command is added by default to react apps. It needs `react-scripts`, which is multiple versions behind. Eject has been removed so that we can clear the dependabot alerts for a more secure codebase.