### PR TITLE
Bump version of loader-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5824,7 +5824,7 @@
       "resolved": "https://registry.npmjs.org/react-intl-loader/-/react-intl-loader-1.0.2.tgz",
       "integrity": "sha512-kuX8mpvuiAbxjFdaj/6fzfNvmGkxTwShkF/ZGCZ02zlV1JVR61nLcUgunFGiDsBxTjE9b/X1DvDyWWQFBvMchg==",
       "dependencies": {
-        "loader-utils": "^0.2.14"
+        "loader-utils": "^2.0.4"
       },
       "peerDependencies": {
         "intl": "^1.1.0",
@@ -10566,8 +10566,8 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
       "requires": {
         "big.js": "^3.1.3",
@@ -11166,7 +11166,7 @@
       "resolved": "https://registry.npmjs.org/react-intl-loader/-/react-intl-loader-1.0.2.tgz",
       "integrity": "sha512-kuX8mpvuiAbxjFdaj/6fzfNvmGkxTwShkF/ZGCZ02zlV1JVR61nLcUgunFGiDsBxTjE9b/X1DvDyWWQFBvMchg==",
       "requires": {
-        "loader-utils": "^0.2.14"
+        "loader-utils": "^2.0.4"
       }
     },
     "react-is": {


### PR DESCRIPTION
This has not been fully tested, but this should fix the security vulnerability. `loader-utils` version 0.* is a dependency of `react-intl-loader`, which is no longer used in connect isolate, so I don't think it will impact the connect widget.